### PR TITLE
Fetch rockets

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,14 @@
 import './sass/index.scss';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import {
+  BrowserRouter, Navigate, Route, Routes,
+} from 'react-router-dom';
 // import store and provider
 import { Provider } from 'react-redux';
 import store from './redux/store';
 import Layout from './components/Layout';
 import Profile from './routes/Profile';
 import Missions from './routes/Missions';
+import Rockets from './routes/Rockets';
 
 function App() {
   return (
@@ -14,6 +17,8 @@ function App() {
         <Provider store={store}>
           <Routes>
             <Route path="/" element={<Layout />}>
+              <Route index element={<Navigate to="/rockets" />} />
+              <Route path="/rockets" element={<Rockets />} />
               <Route path="/profile" element={<Profile />} />
               <Route path="/missions" element={<Missions />} />
             </Route>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -4,6 +4,10 @@ const Navbar = () => {
   const router = useLocation();
   const links = [
     {
+      text: 'Rockets',
+      link: '/rockets',
+    },
+    {
       text: 'Missions',
       link: '/missions',
     },

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -1,0 +1,48 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const URL_MISSION_API = 'https://api.spacexdata.com/v3';
+
+const initialState = {
+  rockets: [],
+  isLoading: true,
+  error: false,
+};
+
+export const getRocketsFromApi = createAsyncThunk(
+  'rockets/getRocketsFromApi',
+  async (payload, thunkAPI) => {
+    try {
+      const resp = await axios.get(`${URL_MISSION_API}/rockets`, { });
+      const { data } = resp;
+
+      return data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.message);
+    }
+  },
+);
+
+const rocketsSlice = createSlice({
+  name: 'rockets',
+  initialState,
+  extraReducers: (builder) => {
+    builder
+      .addCase(getRocketsFromApi.pending, (state) => ({ ...state, isLoading: true }))
+      .addCase(getRocketsFromApi.fulfilled, (state, { payload }) => {
+        const rockets = payload.map((rocket) => ({
+          id: rocket.rocket_id,
+          name: rocket.rocket_name,
+          type: rocket.rocket_type,
+          flickr_images: [...rocket.flickr_images],
+        }));
+
+        return { ...state, isLoading: false, rockets };
+      })
+      .addCase(getRocketsFromApi.rejected,
+        (state) => ({ ...state, isLoading: false, error: true }));
+  },
+});
+
+const rocketsReducer = rocketsSlice.reducer;
+export default rocketsReducer;

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -35,6 +35,7 @@ const rocketsSlice = createSlice({
           name: rocket.rocket_name,
           type: rocket.rocket_type,
           flickr_images: [...rocket.flickr_images],
+          description: rocket.description,
         }));
 
         return { ...state, isLoading: false, rockets };

--- a/src/redux/store.jsx
+++ b/src/redux/store.jsx
@@ -1,9 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
+import logger from 'redux-logger';
 import missionsReducer from './missions/missionsSlice';
+import rocketsReducer from './rockets/rocketsSlice';
 
 const store = configureStore({
   reducer: {
     missions: missionsReducer,
+    rockets: rocketsReducer,
   },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
 });
 export default store;

--- a/src/routes/Missions.jsx
+++ b/src/routes/Missions.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { getMissionFromApi } from '../redux/missions/missionsSlice';
 
@@ -6,11 +6,11 @@ const Missions = () => {
   const dispatch = useDispatch();
   const missions = useSelector((state) => state.missions.missions);
 
-  if (missions.length === 0) {
-    setTimeout(() => {
+  useEffect(() => {
+    if (missions.length === 0) {
       dispatch(getMissionFromApi());
-    }, '1000');
-  }
+    }
+  }, [missions, dispatch]);
 
   return (
     <main className="mission-main">

--- a/src/routes/Rockets.jsx
+++ b/src/routes/Rockets.jsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { getRocketsFromApi } from '../redux/rockets/rocketsSlice';
+
+const Rockets = () => {
+  const dispatch = useDispatch();
+  const rockets = useSelector((state) => state.rockets.rockets);
+
+  useEffect(() => {
+    if (rockets.length === 0) {
+      dispatch(getRocketsFromApi());
+    }
+  }, [rockets, dispatch]);
+
+  return (
+    <main className="rockets-main">
+      <section className="rockets-section"> Rockets </section>
+    </main>
+  );
+};
+
+export default Rockets;


### PR DESCRIPTION
In this PR the following were implemented:

- Rocket slice functionality was added with a reducer to fetch data from API.
- Applied redux-logger to the redux store to log redux manipulation on the console.
- New route to rockets page.